### PR TITLE
Expand model variants and aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,26 @@
 - 支持根据官网 /api/models 生成模型列表，并自动选择合适的模型名称。
 - （登录后）支持上传图片，使用 GLM 识图系列模型。
 - 支持智能识别思考链，完美转换多种格式。
+- 通过模型别名（如 `GLM-4.5-Thinking`、`GLM-4.5-Search`）即可开启思考或搜索功能。
 
+## 模型别名与变体
+
+项目会为常见模型提供统一别名，并在此基础上扩展 `-Thinking` 与 `-Search` 变体：
+
+| 上游 ID | 别名 |
+| --- | --- |
+| `0727-360B-API` | `GLM-4.5` |
+| `glm-4.5v` | `GLM-4.5V` |
+| `0727-106B-API` | `GLM-4.5-Air` |
+| `0808-360B-DR` | `0808-360b-Dr` |
+| `deep-research` | `Z1-Rumination` |
+| `GLM-4-6-API-V1` | `GLM-4.6` |
+| `glm-4-flash` | `GLM-4-Flash` |
+| `GLM-4.1V-Thinking-FlashX` | `GLM-4.1V-Thinking-FlashX` |
+| `main_chat` | `GLM-4-32B` |
+| `zero` | `Z1-32B` |
+
+使用 `-Thinking` 变体会强制开启推理内容输出，`-Search` 变体会自动注入联网搜索所需的特性与 MCP 配置；未带后缀的别名保持上游默认能力。
 ## 要求
 ![Python 3.12+](https://img.shields.io/badge/3.12%2B-blue?style=for-the-badge&logo=python&label=python)
 ![.env](https://img.shields.io/badge/.env-%23555?style=for-the-badge&logo=.env)
@@ -28,6 +47,15 @@
 ### `TOKEN`
   - 访问令牌
   - 如果启用了 `ANONYMOUS_MODE` 可不填
+### `TOKEN_POOL`
+  - 令牌池，支持逗号或换行分隔的多个令牌
+  - 会在非匿名模式下按轮询方式自动切换
+### `TOKEN_POOL_FAILURE_THRESHOLD`
+  - 同一令牌连续失败多少次后暂时标记为不可用
+  - 默认值：`3`
+### `TOKEN_POOL_RESET_FAILURES`
+  - 令牌在失败后多久（秒）重新尝试
+  - 默认值：`1800`
 ### `ANONYMOUS_MODE`
   - 访客模式，启用后将获取随机令牌
   - 默认值：`true`


### PR DESCRIPTION
## Summary
- add a centralized alias map covering all supported upstream models including the GLM-4.6 nickname
- auto-generate standard, thinking, and search variants for each alias so reasoning and search toggles work beyond GLM-4.5
- document the alias table and variant behavior in the README for easier discovery

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_b_68e21a15f394832084cb1e97e436ea27